### PR TITLE
Update urls.py - Replace "url(" by "re_path(" for new versions of Django

### DIFF
--- a/omero_forms/urls.py
+++ b/omero_forms/urls.py
@@ -62,7 +62,7 @@ urlpatterns = [
         name="omeroforms_save_form_data",
     ),
     # Save a form assignment
-    url(
+    re_path(
         r"^save_form_assignment/$",
         views.save_form_assignment,
         name="omeroforms_save_form_assignment",

--- a/omero_forms/urls.py
+++ b/omero_forms/urls.py
@@ -1,61 +1,61 @@
-from django.conf.urls import url
+from django.conf.urls import re_path
 from . import views
 
 urlpatterns = [
     # Designer App
-    url(r"^designer/$", views.designer, name="omeroforms_designer"),
+    re_path(r"^designer/$", views.designer, name="omeroforms_designer"),
     # API
-    url(r"^$", lambda x: None, name="omeroforms_base"),
+    re_path(r"^$", lambda x: None, name="omeroforms_base"),
     # List all forms
-    url(r"^list_forms/$", views.list_forms, name="omeroforms_list_forms"),
+    re_path(r"^list_forms/$", views.list_forms, name="omeroforms_list_forms"),
     # List the forms that are assigned to the user's active group that
     # apply to the object type
-    url(
+    re_path(
         r"^list_applicable_forms/(?P<obj_type>\w+)/$",
         views.list_applicable_forms,
         name="omeroforms_list_applicable_forms",
     ),
     # Get a form (latest version)
-    url(r"^get_form/(?P<form_id>[\w ]+)/$", views.get_form, name="omeroforms_get_form"),
+    re_path(r"^get_form/(?P<form_id>[\w ]+)/$", views.get_form, name="omeroforms_get_form"),
     # Get data for a form (latest version) for a certain object
-    url(
+    re_path(
         r"^get_form_data/"
         r"(?P<form_id>[\w ]+)/(?P<obj_type>\w+)/(?P<obj_id>[\w ]+)/$",
         views.get_form_data,
         name="omeroforms_get_form_data",
     ),
     # Get assignments (restricted to those the user can unassign)
-    url(
+    re_path(
         r"get_form_assignments/$",
         views.get_form_assignments,
         name="omeroforms_get_form_assignments",
     ),
     # Get the entire history of a form including all data and the forms used
     # to enter that data
-    url(
+    re_path(
         r"^get_form_data_history/"
         r"(?P<form_id>[\w ]+)/(?P<obj_type>\w+)/(?P<obj_id>[\w ]+)/$",
         views.get_form_data_history,
         name="omeroforms_get_form_data_history",
     ),
     # Get groups that the user can manage
-    url(
+    re_path(
         r"^get_managed_groups/$",
         views.get_managed_groups,
         name="omeroforms_get_managed_groups",
     ),
     # Lookup usernames by uid
-    url(r"^get_users/$", views.get_users, name="omeroforms_get_users"),
+    re_path(r"^get_users/$", views.get_users, name="omeroforms_get_users"),
     # Check form id ownership
-    url(
+    re_path(
         r"^get_formid_editable/(?P<form_id>[\w ]+)/$",
         views.get_formid_editable,
         name="omeroforms_get_formid_editable",
     ),
     # Save a form version (potentially a new form)
-    url(r"^save_form/$", views.save_form, name="omeroforms_save_form"),
+    re_path(r"^save_form/$", views.save_form, name="omeroforms_save_form"),
     # Save data for a form
-    url(
+    re_path(
         r"^save_form_data/"
         r"(?P<form_id>[\w ]+)/(?P<obj_type>\w+)/(?P<obj_id>[\w ]+)/$",
         views.save_form_data,

--- a/omero_forms/urls.py
+++ b/omero_forms/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import re_path
+from django.urls import re_path
 from . import views
 
 urlpatterns = [


### PR DESCRIPTION
Updated "from django.conf.urls import url" for "from django.urls import re_path". For new versions of Django otherwise it won't work at all.